### PR TITLE
Style graphic source for mobile.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -284,6 +284,14 @@ h1, h2, h3, h4, h6 {
   margin-bottom: 1em;
 }
 
+.parametric-graphic-source-citation {
+  text-align: start;
+}
+
+.parametric-graphic-source-watermark {
+  text-align: end;
+}
+
 @media screen and (max-width: 450px) {
   .parametric-graphic-source {
     flex-direction: column;
@@ -304,6 +312,7 @@ h1, h2, h3, h4, h6 {
     margin-bottom: 0.5em;
   }
 }
+
 .idyll-scroll {
   margin-top: 0;
   margin-bottom: 0;


### PR DESCRIPTION
Not sure what the upper bound for the screen size should be. 425px is the 'Large Mobile' size in Chrome's responsive inspector. I went with 450px to give it a little more leeway.

![Screen Shot 2020-10-14 at 1 31 13 AM](https://user-images.githubusercontent.com/11954298/95963780-f461e080-0dbc-11eb-84e2-d66e66d44dd9.png)

I also modified the default style a little (making the parametric watermark right aligned when it wraps). Here's it is on 500px width. Seems ok even if there is a little wrapping.

Before:
![Screen Shot 2020-10-14 at 1 41 32 AM](https://user-images.githubusercontent.com/11954298/95965089-6555c800-0dbe-11eb-85cf-9ae57a52bda9.png)

After:
![Screen Shot 2020-10-14 at 1 36 48 AM](https://user-images.githubusercontent.com/11954298/95964523-bd3fff00-0dbd-11eb-8778-b877281a45bd.png)
