### PR TITLE
Remove previews audio / video (copyright concerns)

### DIFF
--- a/components/constants.js
+++ b/components/constants.js
@@ -44,60 +44,58 @@ export const titleOrder = [
 
 export const titleToPreview= {
   [amazon]: {
-    preview: true,
+    type: 'video',
+    media: 'website',
     url: 'amazon.mp4',
     link: 'https://www.amazon.com/Uninhabitable-Earth-Life-After-Warming/dp/0525576711/ref=sr_1_8?dchild=1&keywords=climate+change&qid=1602823273&sr=8-8'
   },
   [facebook]: {
-    preview: true,
+    type: 'video',
+    media: 'website',
     url: 'facebook.mp4',
     link: 'https://www.facebook.com'
   },
   [google]: {
-    preview: true,
+    type: 'video',
+    media: 'website',
     url: 'google.mp4',
     link: 'https://www.google.com/search?sxsrf=ALeKk00O79kGgr0mBB9CXZiHW4rWbwUw2Q%3A1602823226434&source=hp&ei=OiSJX6H9F7aS0PEPvbS-kAk&q=climate+change&oq=climate+change&gs_lcp=CgZwc3ktYWIQAzIHCCMQyQMQJzICCAAyCggAELEDEIMBEEMyBQgAELEDMgIIADICCAAyBQgAELEDMggIABCxAxCDATIICAAQsQMQgwEyAggAOgQIIxAnOgUIABCRAjoLCC4QsQMQxwEQowI6CAguELEDEIMBOgUILhCxAzoECC4QQzoHCAAQsQMQQzoHCC4QsQMQQzoLCC4QsQMQxwEQrwE6BAgAEEM6CAguEMcBEK8BOgUIABDJAzoFCAAQkgNQqQZYvA5gnA9oAHAAeACAAWmIAaYJkgEEMTIuMpgBAKABAaoBB2d3cy13aXo&sclient=psy-ab&ved=0ahUKEwihgrDopbjsAhU2CTQIHT2aD5IQ4dUDCAk&uact=5'
   },
-  // [nyt]: {
-  //   type: 'video',
-  //   url: 'nytimes.mp4'
-  // },
+  [nyt]: {
+    type: 'video',
+    media: 'website',
+    url: 'nytimes.mp4',
+    link: 'https://www.nytimes.com/interactive/2020/07/22/us/covid-testing-rising-cases.html'
+  },
   [parametric]: {
-    preview: true,
+    type: 'video',
+    media: 'website',
     url: 'parametricpress.mp4'
   },
   [oldtownroadVideo]: {
-    preview: false,
+    type: 'video',
+    media: 'video',
+    url: 'oldtownroad.mp4',
     link: 'https://www.youtube.com/watch?v=w2Ov5jzm3j8'
   },
   [threeblueonebrown]: {
-    preview: false,
+    type: 'video',
+    media: 'video',
+    url: '3blue1brown.mp4',
     link: 'https://www.youtube.com/watch?v=HEfHFsfGXjs&vl=it',
   },
-  // [drstrange]: {
-  //   preview: false,
-  //   url: 'drstrange.mp4',
-  // },
-  // [slideshow]: {
-  //   preview: false,
-  //   url: 'slideshow.mp4',
-  // },
   [npr]: {
-    preview: false,
-    link: 'https://www.npr.org/2020/01/29/800964001/digging-into-american-dirt'
+    type: 'image',
+    media: 'audio',
+    url: 'podcast.png',
+    link: 'https://www.npr.org/2020/01/29/800964001/digging-into-american-dirt',
   },
-  // [righteous]: {
-  //   preview: false,
-  //   url: 'song.png'
-  // },
   [oldtownroadAudio]: {
-    preview: false,
+    type: 'image',
+    media: 'audio',
+    url: 'oldtownroad.jpg',
     link: 'https://open.spotify.com/track/2YpeDb67231RjR0MgVLzsG?si=xT8IPnGLQrGiY2hjIazJtw',
   },
-  // [thedaily]: {
-  //   preview: false,
-  //   url: 'thedaily.png'
-  // }
 };
 
 export const debounceTimer = 200;

--- a/components/media-picker/media-picker.js
+++ b/components/media-picker/media-picker.js
@@ -1,33 +1,33 @@
-import * as React from 'react';
-import ReactDOM from 'react-dom';
-import MediaAll from './media-all';
-import { debounceTimer, titleToPreview } from '../constants';
-import { stripPadding, titleFontSize } from './media-title';
-import { mediaTitlePadding } from './media-type';
+import * as React from "react";
+import ReactDOM from "react-dom";
+import MediaAll from "./media-all";
+import { debounceTimer, titleToPreview } from "../constants";
+import { stripPadding, titleFontSize } from "./media-title";
+import { mediaTitlePadding } from "./media-type";
 
 const previewHeight = 135;
 const previewPadding = 8;
 
-const boxShadow = '0px 0px 12px 0px rgba(0,0,0,0.75)';
+const boxShadow = "0px 0px 12px 0px rgba(0,0,0,0.75)";
 
-const getOverlayStyle = (width, translateY) => {
+const getOverlayStyle = (width, translateY, orient) => {
   return {
-    position: 'absolute',
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
+    position: "absolute",
+    display: "flex",
+    flexDirection: orient === 'bottom' ? "column" : 'column-reverse',
+    alignItems: "center",
     zIndex: 2,
     left: 0,
     right: 0,
-    top,
-    marginLeft: 'auto',
-    marginRight: 'auto',
+    top: translateY,
+    marginLeft: "auto",
+    marginRight: "auto",
     maxWidth: width,
-    transform: `${translateY} translateZ(0)`,
-    boxShadow: boxShadow,
-    lineHeight: 0
-  }
-}
+    transform: `translateY(${orient === 'bottom' ? 0 : '-100%'})`,
+    // transform: `translateY(${translateY}px) translateZ(0)`,
+    lineHeight: 0,
+  };
+};
 
 export default class MediaPicker extends React.Component {
   constructor(props) {
@@ -45,6 +45,7 @@ export default class MediaPicker extends React.Component {
 
     this.resizeBounce = null;
     this._size = this._size.bind(this);
+    this._measure = this._measure.bind(this);
   }
 
   selectTitle(y, h, t, th) {
@@ -52,8 +53,8 @@ export default class MediaPicker extends React.Component {
       selectedY: y,
       selectedHeight: h,
       selectedTitle: t,
-      selectedTitleHeight: th
-    })
+      selectedTitleHeight: th,
+    });
   }
 
   clearTitle() {
@@ -62,14 +63,14 @@ export default class MediaPicker extends React.Component {
 
   componentDidMount() {
     this.node = ReactDOM.findDOMNode(this);
-    window.addEventListener('click', (e) => {
+    window.addEventListener("click", (e) => {
       if (!e.target.isSameNode(this.node)) {
         this.clearTitle();
       }
     });
     setTimeout(() => {
       this._size();
-      window.addEventListener('resize', this._onResize.bind(this));
+      window.addEventListener("resize", this._onResize.bind(this));
     }, 100);
   }
 
@@ -78,19 +79,26 @@ export default class MediaPicker extends React.Component {
     this.setState({
       width: rect.width,
     });
+
+    this._measure();
   }
 
   _onResize() {
     if (this.resizeBounce) {
       clearTimeout(this.resizeBounce);
     }
-    
+
     this.resizeBounce = setTimeout(this._size, debounceTimer);
   }
 
-  componentDidUpdate() {
-    const rect = ReactDOM.findDOMNode(this).getBoundingClientRect();
-    this.height = rect.height;
+  _measure() {
+    const node = ReactDOM.findDOMNode(this);
+    if (node) {
+      const rect = node.getBoundingClientRect();
+      this.y = rect.y;
+      this.height = rect.height;
+      this.windowHeight = window.innerHeight;
+    }
   }
 
   render() {
@@ -111,105 +119,149 @@ export default class MediaPicker extends React.Component {
     let previews;
     if (shouldPreload) {
       previews = Object.keys(titleToPreview)
-      .filter(title => data.filter(d => d.title === title).length > 0)
-      .map(title => {
-        const item = titleToPreview[title];
-        
-        const style = { position: 'absolute', width: 100, height: 100, top: 0, left: 0, opacity: 0};
-  
-        if (item.preview) {
-          return (
-            <video key={title + "-preload"} style={style} preload="auto" autoPlay loop muted playsInline>
-              <source src={`./static/images/${item.url}`} type="video/mp4"/>
-            </video>
-          );
-        }
-      });
+        .filter((title) => data.filter((d) => d.title === title).length > 0)
+        .map((title) => {
+          const item = titleToPreview[title];
+
+          const style = {
+            position: "absolute",
+            width: 100,
+            height: 100,
+            top: 0,
+            left: 0,
+            opacity: 0,
+          };
+
+          if (item.type === "video") {
+            return (
+              <video
+                key={title + "-preload"}
+                style={style}
+                preload="auto"
+                autoPlay
+                loop
+                muted
+                playsInline
+              >
+                <source src={`./static/images/${item.url}`} type="video/mp4" />
+              </video>
+            );
+          }
+        });
     }
 
     let preview;
     let overlayStyle;
     let link;
     if (selectedTitle) {
+      this._measure();
       const item = titleToPreview[selectedTitle];
-      if (item.preview) {
-        const offset = selectedHeight + previewPadding;
-        const translateY = `translateY(${selectedY + offset}px)`;
-        const overlayWidth = this.state.width - previewPadding * 2;
-        overlayStyle = getOverlayStyle(overlayWidth, translateY);
-        
-        if (item.link) {
-          link = (
-              <button
-                onClick={function() { window.open(item.link, "_blank"); }}
-                style={{margin: 0, width: '100%', cursor: 'pointer'}}>
-                  visit webpage
-              </button>
-          );
-        }
 
-        const style = {
-          width: overlayWidth,
-          backgroundColor: '#000',
-          marginBottom: previewPadding
-        };
+      const offset = selectedHeight + previewPadding;
+      const overlayWidth = this.state.width - previewPadding * 2;
+
+      const impliedHeight = item.type === 'video' ? overlayWidth * 0.6 : overlayWidth;
+      
+      const buttonHeight = 20;
+      let orient;
+      if (selectedY + offset + impliedHeight + buttonHeight + this.y + 16 > this.windowHeight) {
+        orient = 'top';
+      } else {
+        orient = 'bottom';
+      }
+
+      let translateY;
+      if (orient === 'top') {
+        translateY = selectedY - previewPadding;
+      } else {
+        translateY = selectedY + offset;
+      }
+
+      console.log(translateY);
+
+      overlayStyle = getOverlayStyle(overlayWidth,  translateY, orient);
+
+      let linkText;
+      if (item.media === "website") {
+        linkText = "visit webpage";
+      } else {
+        linkText = "visit source";
+      }
+
+      if (item.link) {
+        link = (
+          <button
+            onClick={function () {
+              window.open(item.link, "_blank");
+            }}
+            style={{
+              margin: 0,
+              width: "100%",
+              // paddingTop: "1em",
+              // paddingBottom: "1em",
+              cursor: "pointer",
+              boxShadow: boxShadow,
+            }}
+          >
+            {linkText}
+          </button>
+        );
+      }
+
+      const style = {
+        width: overlayWidth,
+        backgroundColor: "#000",
+        marginBottom: orient === 'bottom' ? previewPadding : 0,
+        marginTop: orient === 'top' ? previewPadding : 0,
+        boxShadow: boxShadow,
+      };
+
+      if (item.type === "video") {
         preview = (
           <video style={style} key={selectedTitle} autoPlay muted playsInline>
-            <source src={`./static/images/${item.url}`} type="video/mp4"/>
+            <source src={`./static/images/${item.url}`} type="video/mp4" />
           </video>
         );
       } else {
-        overlayStyle = {
-          position: 'absolute',
-          right: previewPadding,
-          top: selectedY + selectedTitleHeight - 12,
-          zIndex: 2,
-          // transform: 'translateY(-50%)'
-        }
-
-        link =
-          <button
-          onClick={function() { window.open(item.link, "_blank"); }}
-          style={{
-            width: '4em', 
-            height: selectedHeight - selectedTitleHeight,
-            textAlign: 'center',
-            padding: 0,
-            cursor: 'pointer',
-            boxShadow: boxShadow
-        }}>❞</button>;
+        preview = <img style={style} src={`./static/images/${item.url}`}></img>;
       }
     }
 
     const overlay = (
-      <div key={selectedTitle || 'overlay'} style={overlayStyle}>
+      <div key={selectedTitle || "overlay"} style={overlayStyle}>
         {preview}
         {link}
       </div>
-    )
-    
+    );
 
     return (
-      <div className="media-picker"
+      <div
+        className="media-picker"
         // onContextMenu={function(e) { e.preventDefault();}}
 
         style={{
           width: width,
-          position: 'relative',
-          paddingBottom: '1em'
-      }}>
+          position: "relative",
+          paddingBottom: "1em",
+        }}
+      >
         {previews}
         {overlay}
-        { this.state.width ?
-          <MediaAll type={type}
-            mediaType={mediaType} mediaTitle={mediaTitle} noAutoplayTimeline={noAutoplayTimeline}
-            data={data} width={this.state.width} headers={headers} inline={inline}
+        {this.state.width ? (
+          <MediaAll
+            type={type}
+            mediaType={mediaType}
+            mediaTitle={mediaTitle}
+            noAutoplayTimeline={noAutoplayTimeline}
+            data={data}
+            width={this.state.width}
+            headers={headers}
+            inline={inline}
             selectTitle={this.selectTitle}
             hasSelected={this.state.selectedY !== null}
             selectedTitle={selectedTitle}
           />
-          : null
-        }
+        ) : null}
       </div>
     );
   }

--- a/data/combine.js
+++ b/data/combine.js
@@ -23,7 +23,6 @@ files.forEach(f => {
 });
 
 const nolist = [
-  'The New York Times (interactive article)',
   'Digging into American Dirt (podcast) (old)',
   'Righteous (song)',
   'Slideshow',

--- a/data/dist/media-emissions.json
+++ b/data/dist/media-emissions.json
@@ -3180,6 +3180,677 @@
     ]
   },
   {
+    "mediaType": "website",
+    "title": "The New York Times (interactive article)",
+    "packets": [
+      {
+        "time": 0,
+        "sizeInBytes": 656664,
+        "size": 0.0027855686880000003
+      },
+      {
+        "time": 0.145,
+        "sizeInBytes": 61921,
+        "size": 0.00026266888199999997
+      },
+      {
+        "time": 0.146,
+        "sizeInBytes": 4669,
+        "size": 0.000019805897999999997
+      },
+      {
+        "time": 0.398,
+        "sizeInBytes": 11918,
+        "size": 0.000050556156
+      },
+      {
+        "time": 0.401,
+        "sizeInBytes": 14097,
+        "size": 0.000059799474
+      },
+      {
+        "time": 0.402,
+        "sizeInBytes": 38,
+        "size": 1.61196e-7
+      },
+      {
+        "time": 0.404,
+        "sizeInBytes": 60471,
+        "size": 0.0002565179819999999
+      },
+      {
+        "time": 0.407,
+        "sizeInBytes": 5074,
+        "size": 0.000021523907999999998
+      },
+      {
+        "time": 0.531,
+        "sizeInBytes": 579,
+        "size": 0.0000024561179999999993
+      },
+      {
+        "time": 0.538,
+        "sizeInBytes": 104553,
+        "size": 0.000443513826
+      },
+      {
+        "time": 0.542,
+        "sizeInBytes": 1923,
+        "size": 0.000008157366000000001
+      },
+      {
+        "time": 0.562,
+        "sizeInBytes": 19836,
+        "size": 0.000084144312
+      },
+      {
+        "time": 0.563,
+        "sizeInBytes": 20136,
+        "size": 0.000085416912
+      },
+      {
+        "time": 0.564,
+        "sizeInBytes": 28620,
+        "size": 0.00012140603999999999
+      },
+      {
+        "time": 0.588,
+        "sizeInBytes": 28604,
+        "size": 0.00012133816799999999
+      },
+      {
+        "time": 0.59,
+        "sizeInBytes": 28252,
+        "size": 0.000119844984
+      },
+      {
+        "time": 0.599,
+        "sizeInBytes": 28,
+        "size": 1.1877599999999999e-7
+      },
+      {
+        "time": 0.6,
+        "sizeInBytes": 58580,
+        "size": 0.00024849636
+      },
+      {
+        "time": 0.609,
+        "sizeInBytes": 75487,
+        "size": 0.000320215854
+      },
+      {
+        "time": 0.697,
+        "sizeInBytes": 55622,
+        "size": 0.000235948524
+      },
+      {
+        "time": 0.733,
+        "sizeInBytes": 685002,
+        "size": 0.0029057784839999997
+      },
+      {
+        "time": 0.734,
+        "sizeInBytes": 320920,
+        "size": 0.0013613426399999998
+      },
+      {
+        "time": 0.786,
+        "sizeInBytes": 8785045,
+        "size": 0.03726616089
+      },
+      {
+        "time": 0.808,
+        "sizeInBytes": 6482,
+        "size": 0.000027496644
+      },
+      {
+        "time": 0.816,
+        "sizeInBytes": 26488,
+        "size": 0.000112362096
+      },
+      {
+        "time": 0.82,
+        "sizeInBytes": 28276,
+        "size": 0.000119946792
+      },
+      {
+        "time": 0.836,
+        "sizeInBytes": 141919,
+        "size": 0.000602020398
+      },
+      {
+        "time": 0.886,
+        "sizeInBytes": 265940,
+        "size": 0.00112811748
+      },
+      {
+        "time": 0.889,
+        "sizeInBytes": 14097,
+        "size": 0.000059799474
+      },
+      {
+        "time": 0.89,
+        "sizeInBytes": 38,
+        "size": 1.61196e-7
+      },
+      {
+        "time": 1.306,
+        "sizeInBytes": 266716,
+        "size": 0.0011314092719999999
+      },
+      {
+        "time": 1.308,
+        "sizeInBytes": 578,
+        "size": 0.000002451876
+      },
+      {
+        "time": 1.321,
+        "sizeInBytes": 200,
+        "size": 8.483999999999999e-7
+      },
+      {
+        "time": 1.34,
+        "sizeInBytes": 2465,
+        "size": 0.00001045653
+      },
+      {
+        "time": 1.518,
+        "sizeInBytes": 71514,
+        "size": 0.00030336238799999997
+      },
+      {
+        "time": 1.523,
+        "sizeInBytes": 221888,
+        "size": 0.0009412488959999999
+      },
+      {
+        "time": 1.751,
+        "sizeInBytes": 519,
+        "size": 0.0000022015979999999998
+      },
+      {
+        "time": 1.769,
+        "sizeInBytes": 250,
+        "size": 0.0000010605
+      },
+      {
+        "time": 1.779,
+        "sizeInBytes": 100,
+        "size": 4.2419999999999995e-7
+      },
+      {
+        "time": 1.808,
+        "sizeInBytes": 12319,
+        "size": 0.00005225719799999999
+      },
+      {
+        "time": 2.04,
+        "sizeInBytes": 76443,
+        "size": 0.000324271206
+      },
+      {
+        "time": 2.103,
+        "sizeInBytes": 45958,
+        "size": 0.000194953836
+      },
+      {
+        "time": 2.104,
+        "sizeInBytes": 4550,
+        "size": 0.0000193011
+      },
+      {
+        "time": 2.122,
+        "sizeInBytes": 36456,
+        "size": 0.00015464635199999996
+      },
+      {
+        "time": 2.145,
+        "sizeInBytes": 30799,
+        "size": 0.000130649358
+      },
+      {
+        "time": 2.147,
+        "sizeInBytes": 105675,
+        "size": 0.00044827334999999997
+      },
+      {
+        "time": 2.158,
+        "sizeInBytes": 35,
+        "size": 1.4847e-7
+      },
+      {
+        "time": 2.167,
+        "sizeInBytes": 15152,
+        "size": 0.000064274784
+      },
+      {
+        "time": 2.185,
+        "sizeInBytes": 724,
+        "size": 0.0000030712079999999997
+      },
+      {
+        "time": 2.301,
+        "sizeInBytes": 2,
+        "size": 8.484e-9
+      },
+      {
+        "time": 2.312,
+        "sizeInBytes": 222,
+        "size": 9.417239999999998e-7
+      },
+      {
+        "time": 2.337,
+        "sizeInBytes": 42,
+        "size": 1.7816399999999998e-7
+      },
+      {
+        "time": 2.404,
+        "sizeInBytes": 43,
+        "size": 1.8240599999999997e-7
+      },
+      {
+        "time": 2.429,
+        "sizeInBytes": 35,
+        "size": 1.4847e-7
+      },
+      {
+        "time": 2.431,
+        "sizeInBytes": 62,
+        "size": 2.6300399999999996e-7
+      },
+      {
+        "time": 2.446,
+        "sizeInBytes": 1149,
+        "size": 0.000004874057999999999
+      },
+      {
+        "time": 2.545,
+        "sizeInBytes": 278,
+        "size": 0.0000011792759999999996
+      },
+      {
+        "time": 2.59,
+        "sizeInBytes": 23,
+        "size": 9.7566e-8
+      },
+      {
+        "time": 2.613,
+        "sizeInBytes": 40472,
+        "size": 0.00017168222399999999
+      },
+      {
+        "time": 2.62,
+        "sizeInBytes": 41675,
+        "size": 0.00017678535
+      },
+      {
+        "time": 2.636,
+        "sizeInBytes": 80896,
+        "size": 0.000343160832
+      },
+      {
+        "time": 2.637,
+        "sizeInBytes": 45738,
+        "size": 0.00019402059599999997
+      },
+      {
+        "time": 2.638,
+        "sizeInBytes": 26476,
+        "size": 0.000112311192
+      },
+      {
+        "time": 2.706,
+        "sizeInBytes": 5810,
+        "size": 0.00002464602
+      },
+      {
+        "time": 2.71,
+        "sizeInBytes": 73313,
+        "size": 0.00031099374599999997
+      },
+      {
+        "time": 2.89,
+        "sizeInBytes": 43,
+        "size": 1.8240599999999997e-7
+      },
+      {
+        "time": 2.929,
+        "sizeInBytes": 62,
+        "size": 2.6300399999999996e-7
+      },
+      {
+        "time": 2.95,
+        "sizeInBytes": 62,
+        "size": 2.6300399999999996e-7
+      },
+      {
+        "time": 2.971,
+        "sizeInBytes": 10957,
+        "size": 0.000046479594000000005
+      },
+      {
+        "time": 2.973,
+        "sizeInBytes": 75904,
+        "size": 0.00032198476799999995
+      },
+      {
+        "time": 2.974,
+        "sizeInBytes": 13160,
+        "size": 0.000055824719999999996
+      },
+      {
+        "time": 2.977,
+        "sizeInBytes": 24363,
+        "size": 0.00010334784599999999
+      },
+      {
+        "time": 3.104,
+        "sizeInBytes": 10784,
+        "size": 0.000045745728
+      },
+      {
+        "time": 3.107,
+        "sizeInBytes": 17152,
+        "size": 0.00007275878400000001
+      },
+      {
+        "time": 3.11,
+        "sizeInBytes": 6402,
+        "size": 0.000027157283999999998
+      },
+      {
+        "time": 3.112,
+        "sizeInBytes": 22434,
+        "size": 0.000095165028
+      },
+      {
+        "time": 3.116,
+        "sizeInBytes": 44314,
+        "size": 0.00018797998799999997
+      },
+      {
+        "time": 3.228,
+        "sizeInBytes": 7613,
+        "size": 0.000032294346
+      },
+      {
+        "time": 3.375,
+        "sizeInBytes": 74907,
+        "size": 0.000317755494
+      },
+      {
+        "time": 3.433,
+        "sizeInBytes": 53897,
+        "size": 0.000228631074
+      },
+      {
+        "time": 3.561,
+        "sizeInBytes": 2279,
+        "size": 0.000009667518
+      },
+      {
+        "time": 3.881,
+        "sizeInBytes": 4922,
+        "size": 0.000020879123999999997
+      },
+      {
+        "time": 3.882,
+        "sizeInBytes": 807,
+        "size": 0.0000034232939999999997
+      },
+      {
+        "time": 3.908,
+        "sizeInBytes": 1304,
+        "size": 0.000005531567999999999
+      },
+      {
+        "time": 3.918,
+        "sizeInBytes": 30190,
+        "size": 0.00012806598
+      },
+      {
+        "time": 3.986,
+        "sizeInBytes": 42141,
+        "size": 0.000178762122
+      },
+      {
+        "time": 4.073,
+        "sizeInBytes": 6493,
+        "size": 0.000027543306
+      },
+      {
+        "time": 4.077,
+        "sizeInBytes": 41610,
+        "size": 0.00017650962
+      },
+      {
+        "time": 4.095,
+        "sizeInBytes": 273267,
+        "size": 0.0011591986139999999
+      },
+      {
+        "time": 4.147,
+        "sizeInBytes": 22890,
+        "size": 0.00009709938
+      },
+      {
+        "time": 4.258,
+        "sizeInBytes": 12230,
+        "size": 0.000051879659999999994
+      },
+      {
+        "time": 4.263,
+        "sizeInBytes": 4441,
+        "size": 0.000018838722000000003
+      },
+      {
+        "time": 4.381,
+        "sizeInBytes": 19249,
+        "size": 0.000081654258
+      },
+      {
+        "time": 4.386,
+        "sizeInBytes": 105707,
+        "size": 0.000448409094
+      },
+      {
+        "time": 4.402,
+        "sizeInBytes": 91985,
+        "size": 0.00039020037
+      },
+      {
+        "time": 4.434,
+        "sizeInBytes": 13712,
+        "size": 0.00005816630399999999
+      },
+      {
+        "time": 4.539,
+        "sizeInBytes": 2679,
+        "size": 0.000011364318000000002
+      },
+      {
+        "time": 4.54,
+        "sizeInBytes": 109796,
+        "size": 0.000465754632
+      },
+      {
+        "time": 4.615,
+        "sizeInBytes": 273267,
+        "size": 0.0011591986139999999
+      },
+      {
+        "time": 4.664,
+        "sizeInBytes": 226,
+        "size": 9.58692e-7
+      },
+      {
+        "time": 4.98,
+        "sizeInBytes": 42,
+        "size": 1.7816399999999998e-7
+      },
+      {
+        "time": 5.101,
+        "sizeInBytes": 5683,
+        "size": 0.000024107285999999997
+      },
+      {
+        "time": 5.105,
+        "sizeInBytes": 12230,
+        "size": 0.000051879659999999994
+      },
+      {
+        "time": 5.883,
+        "sizeInBytes": 807,
+        "size": 0.0000034232939999999997
+      },
+      {
+        "time": 5.913,
+        "sizeInBytes": 42,
+        "size": 1.7816399999999998e-7
+      },
+      {
+        "time": 6.622,
+        "sizeInBytes": 67,
+        "size": 2.8421400000000003e-7
+      },
+      {
+        "time": 7.213,
+        "sizeInBytes": 67,
+        "size": 2.8421400000000003e-7
+      },
+      {
+        "time": 7.62,
+        "sizeInBytes": 67,
+        "size": 2.8421400000000003e-7
+      },
+      {
+        "time": 7.789,
+        "sizeInBytes": 2,
+        "size": 8.484e-9
+      },
+      {
+        "time": 8.209,
+        "sizeInBytes": 67,
+        "size": 2.8421400000000003e-7
+      },
+      {
+        "time": 9.438,
+        "sizeInBytes": 1324,
+        "size": 0.0000056164079999999995
+      },
+      {
+        "time": 9.439,
+        "sizeInBytes": 567,
+        "size": 0.0000024052140000000002
+      },
+      {
+        "time": 9.44,
+        "sizeInBytes": 875,
+        "size": 0.0000037117499999999997
+      },
+      {
+        "time": 9.441,
+        "sizeInBytes": 1138,
+        "size": 0.000004827396
+      },
+      {
+        "time": 9.442,
+        "sizeInBytes": 669,
+        "size": 0.0000028378979999999995
+      },
+      {
+        "time": 9.443,
+        "sizeInBytes": 881,
+        "size": 0.000003737202
+      },
+      {
+        "time": 9.444,
+        "sizeInBytes": 735,
+        "size": 0.0000031178699999999994
+      },
+      {
+        "time": 9.445,
+        "sizeInBytes": 935,
+        "size": 0.00000396627
+      },
+      {
+        "time": 9.446,
+        "sizeInBytes": 991,
+        "size": 0.000004203822
+      },
+      {
+        "time": 9.447,
+        "sizeInBytes": 726,
+        "size": 0.000003079692
+      },
+      {
+        "time": 9.448,
+        "sizeInBytes": 758,
+        "size": 0.0000032154359999999995
+      },
+      {
+        "time": 9.449,
+        "sizeInBytes": 795,
+        "size": 0.0000033723899999999994
+      },
+      {
+        "time": 9.45,
+        "sizeInBytes": 605,
+        "size": 0.00000256641
+      },
+      {
+        "time": 9.451,
+        "sizeInBytes": 5592,
+        "size": 0.000023721264
+      },
+      {
+        "time": 9.452,
+        "sizeInBytes": 6236,
+        "size": 0.000026453112
+      },
+      {
+        "time": 9.732,
+        "sizeInBytes": 67,
+        "size": 2.8421400000000003e-7
+      },
+      {
+        "time": 10.318,
+        "sizeInBytes": 67,
+        "size": 2.8421400000000003e-7
+      },
+      {
+        "time": 15.227,
+        "sizeInBytes": 42,
+        "size": 1.7816399999999998e-7
+      },
+      {
+        "time": 17.402,
+        "sizeInBytes": 43,
+        "size": 1.8240599999999997e-7
+      },
+      {
+        "time": 25.224,
+        "sizeInBytes": 42,
+        "size": 1.7816399999999998e-7
+      },
+      {
+        "time": 32.407,
+        "sizeInBytes": 43,
+        "size": 1.8240599999999997e-7
+      },
+      {
+        "time": 47.404,
+        "sizeInBytes": 43,
+        "size": 1.8240599999999997e-7
+      },
+      {
+        "time": 55.225,
+        "sizeInBytes": 42,
+        "size": 1.7816399999999998e-7
+      }
+    ]
+  },
+  {
     "mediaType": "audio",
     "title": "Lil Nas X: Old Town Road (song)",
     "packets": [

--- a/index.idyll
+++ b/index.idyll
@@ -144,7 +144,7 @@ As shown [span className:"showLargeScreen"]to the right[/span][span className:"s
 [LargeAside]
 [ParametricGraphic hed:"Emissions of Audio" style:emissionGraphicPadding source:emissionSource]
 [MediaPicker type:"bar" mediaType:"audio" data:mediaPickerData width:"100%" headers:false/]
-[caption]Each bar represents the carbon emitted when listening to an audio clip for 60 seconds. (No audio preview). [span className:"desktopInstructions"]Clicking[/span][span className:"touchscreenInstructions"]Tapping[/span] a bar will reveal a button that takes you to the source.[/caption]
+[caption]Each bar represents the carbon emitted when listening to an audio clip for 60 seconds. (No audio preview).
 [/ParametricGraphic]
 [/LargeAside]
 [/div]
@@ -157,7 +157,7 @@ In practice, this size is often determined by the choice of [span className:"ter
 [LargeAside]
 [ParametricGraphic hed:"Emissions of Audio" style:emissionGraphicPadding source:emissionSource]
 [MediaPicker type:"bar" mediaType:"audio" data:mediaPickerData width:"100%" headers:false/]
-[caption]Each bar represents the carbon emitted when listening to an audio clip for 60 seconds. (No audio preview). [span className:"desktopInstructions"]Clicking[/span][span className:"touchscreenInstructions"]Tapping[/span] a bar will reveal a button that takes you to the source.[/caption]
+[caption]Each bar represents the carbon emitted when listening to an audio clip for 60 seconds. (No audio preview).
 [/ParametricGraphic]
 [/LargeAside]
 [/div]

--- a/yarn.lock
+++ b/yarn.lock
@@ -9535,18 +9535,18 @@ param-case@^3.0.3:
     dot-case "^3.0.3"
     tslib "^1.10.0"
 
-parametric-components@^2.1.21:
-  version "2.1.21"
-  resolved "https://registry.yarnpkg.com/parametric-components/-/parametric-components-2.1.21.tgz#5c2828c7f83b8a9f77b0d88c79c7c3678cb3b5d8"
-  integrity sha512-mIPh+ew75Eak6KaFJCj+kUBrrF+dzM3EJR7gLpyRdelXDzXpSP/bEHy3xYhLMqThEXSuO7iGXsvaDaNIYq9XJw==
+parametric-components@^2.1.26:
+  version "2.1.28"
+  resolved "https://registry.yarnpkg.com/parametric-components/-/parametric-components-2.1.28.tgz#8f3b656c08500fcd1430ad7acbc7c1a7526cfaa1"
+  integrity sha512-3/Zf6QNvbtSqDZWs+BJeQ8IvwF4thlIZIuygjzaOZVPzWUIrVkouYbobwgzo2u2xKN0Usr7fgqqjMqcfct4bTg==
   dependencies:
     idyll-components "^3.12.1"
     react-tooltip "^3.11.6"
 
-parametric-styles@^2.2.11:
-  version "2.2.12"
-  resolved "https://registry.yarnpkg.com/parametric-styles/-/parametric-styles-2.2.12.tgz#7b38e5ac5d8331a6ecd300692554ab69cc227d60"
-  integrity sha512-Ce01xQQEebDXVjUpxhEqJQVYJaEGi9+20+AhMfjqotyenwFFUWczH0MgjD8Aj5VrCUneje1DGsQFZc45MwgHwg==
+parametric-styles@^2.2.17:
+  version "2.2.20"
+  resolved "https://registry.yarnpkg.com/parametric-styles/-/parametric-styles-2.2.20.tgz#a847d2f9f9195c7dea138efb32bc340139efbd28"
+  integrity sha512-txv3UxwYcRZQNdz2dg3wdpqH2vWez0gOkPRTqK7ISGu4D7XIum7O7FHd3xTceDV83aOYV3wDGSq3lqIjw+WYFw==
 
 parent-module@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Remove previews for audio video & add a link source for all media. Remove NYT (paywalled).

**Reasoning:**

* Put 2 + 2 together the other night and realized that our use of album art as the preview for audio was probably just as problematic as using unlicensed photos in the rest of the article. The video preview is similar questionable. Both of these previews don't add enough value imo to carry that ethical / legal risk. Better to just link to the source and provide traffic as a citation.
* Removed the NYT item b/c it is paywalled and this parametric article fills the void of an 'interactive article'. @fredhohman @mathisonian This one was a little more gray to us, would like to hear your thoughts. An added benefit of removing the NYT is it makes the "Media Emissions by Medium" chart a bit shorter so its now able to fit on most desktop and mobile screens (before it would be just a tad too tall for some).
* Kept the previews for the websites. These don't feel like a big a copyright issue (if any?) since they're screen captures of the experience. The benefit of the previews here are that they convey the scroll speed we use. You could also argue that they are a sort of 'archive': web pages will change over time.

**Link for Websites:**
![image](https://user-images.githubusercontent.com/11954298/96220972-9826ca00-0f3e-11eb-9a98-da406d08ed9b.png)

**Link for Audio & Video**
![image](https://user-images.githubusercontent.com/11954298/96221000-a1b03200-0f3e-11eb-88b7-8bddeba71c6e.png)
![image](https://user-images.githubusercontent.com/11954298/96221029-ab399a00-0f3e-11eb-9386-4b22551e593f.png)
