### PR TITLE
Add touchscreen instructions for superfund map caption.

### DIFF
--- a/components/touchscreen-detector.js
+++ b/components/touchscreen-detector.js
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { isTouchScreen } from './util';
+
+export default class TouchcreenDetector extends React.Component {
+  componentDidMount() {
+    this.props.updateProps({
+      isTouchScreen: isTouchScreen()
+    });
+  }
+  
+  render() {
+    return null
+  }
+}

--- a/index.idyll
+++ b/index.idyll
@@ -483,10 +483,18 @@ Digital streaming is not the only instance where environmentally harmful aspects
 Tech is rarely perceived as environmentally toxic, but here's a surprising fact: [span className:"emphasized"]Santa Clara County, the heart of "Silicon Valley", has the most EPA classified "superfund" (highly polluted) sites in the nation[/span].
 These [link text:"23 locations" url:"https://www.theatlantic.com/technology/archive/2019/09/silicon-valley-full-superfund-sites/598531/#:~:text=Santa%20Clara%20County%20has%2023,these%20chemicals%20may%20be%20impossible." target:"_blank"/] may be impossible to fully clean. Silicon Valley is primarily to blame.
 
+[var name:"isTouchScreen" value:false /]
+[TouchscreenDetector isTouchScreen:isTouchScreen /]
+
+[derived name:"superfundCaption" value:`"The 23 superfund sites of Santa Clara County. " +
+  (isTouchScreen ? 'Press the "Enable Touch" button, then tap each site for more information.' :
+    'Hover over each one for more information.') +
+  ' Larger Hazard Ranking System Scores are worse.'`/]
+
 [data name:"superfundSitesGeoJSON" source:"dist/superfund-sites.json"/]
 [var name:"zoomEnabled" value:false/]
 [div className:"superfund-map" fullWidth:true]
-[ParametricGraphic hed:"The Superfund Sites of Santa Clara Valley" subhed:"The 23 superfund sites of Santa Clara County. Hover over each one for more information. Larger Hazard Ranking System Scores are worse." source:`[{label:"EPA", url:"https://www.epa.gov/superfund/search-superfund-sites-where-you-live"}]`]
+[ParametricGraphic hed:"The Superfund Sites of Santa Clara Valley" subhed:superfundCaption source:`[{label:"EPA", url:"https://www.epa.gov/superfund/search-superfund-sites-where-you-live"}]`]
 [SuperfundSites map:"homes" zoomEnabled:zoomEnabled geoJSON:superfundSitesGeoJSON /]
 [/ParametricGraphic]
 [/div]


### PR DESCRIPTION
Right now we only have instructions for desktop in the subhed. This can be a little confusing since (1) you cannot 'hover' on desktop and (2) you need to "enable touch" first on mobile (enabling touch by default will cause scroll-jacking).

![image](https://user-images.githubusercontent.com/11954298/96552018-0eda0500-1268-11eb-984e-f6f6493b80ab.png)

This adds touch screen instructions:

> The 23 superfund sites of Santa Clara County. Trigger the "Enable Touch" button, then tap each site for more information. Larger Hazard Ranking System Scores are worse.
![image](https://user-images.githubusercontent.com/11954298/96552084-23b69880-1268-11eb-971d-1beed89780e8.png)
